### PR TITLE
docs: handling sigterm in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,23 @@ Keploy simplifies the testing process by seamlessly generating end-to-end test c
 Add a test file with the following code to the directory with all your existing tests. This will help us to get the coverage of Keploy's API tests along with the other unit tests. We can call this `test_keploy.py`
 
 ```python
-from Keploy import run
+from keploy import run
 def test_keploy():
     run("python3 -m coverage run --data-file=.coverage_data.keploy <command-to-run-your-application>")
 ```
 
 > Note: If you face any problems with running the coverage library, you can refer to the documentation for the same [here](https://coverage.readthedocs.io/en/7.4.2/cmd.html#execution-coverage-run)
 
-To ignore the coverage of python libraries which are included in the report by default, you can create a .coveragerc file in the directory where you will ignore the /usr/ directory(only for Linux users). The contents of the file will be as follows:
+To ignore the coverage of python libraries which are included in the report by default, you need to create a `.coveragerc` file in the directory where you will ignore the /usr/ directory(only for Linux users). The contents of the file will be as follows:
 
 ```bash
 [run]
 omit =
     /usr/*
+sigterm = true
 ```
 
-Before starting your application, make sure that the debug mode is set to False in your application, for the coverage library to work properly.
+Before starting your application, make sure that the **debug mode is set to False** in your application, for the coverage library to work properly.
 
 Now to run this testcase along with your another unit testcases, you can run the command below:
 


### PR DESCRIPTION
## Issue that this pull request solves

## Proposed changes
Need to add configuration to handle sigterm as Keploy sends sigterm signal to stop applications currently. We are sigterm = true because pytest by default handles only sigint signals but Keploy sends sigterm signals in order to stop application. Therefore in case of keploy, the coverage is not recorded properly. The debug mode is also set to false because the coverage file is not created when debug mode is set to tru.

### Brief description of what is fixed or changed
Add the configuration for doing the same in .coveragerc

## Types of changes

_Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [ ] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [ ] I have performed a self-review of my own code
-   [ ] I have created new branch for this pull request
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] My changes does not break the current system and it passes all the current test cases.


