### PR TITLE
fix: modularized coverage middlewares 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,4 @@
 from .Keploy import run, RunOptions
+from .djangoCov import DjangoCoverageMiddleware
+from .fastApiCov import FastApiCoverageMiddleware
+from .flaskCov import FlaskCoverageMiddleware

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '2.0.0-alpha1'
+VERSION = '2.0.0-alpha36'
 DESCRIPTION = 'Keploy'
 LONG_DESCRIPTION = 'Keploy Python SDK'
 

--- a/src/keploy/__init__.py
+++ b/src/keploy/__init__.py
@@ -1,1 +1,4 @@
 from .Keploy import run, RunOptions
+from .djangoCov import DjangoCoverageMiddleware
+from .fastApiCov import FastApiCoverageMiddleware
+from .flaskCov import FlaskCoverageMiddleware

--- a/src/keploy/djangoCov.py
+++ b/src/keploy/djangoCov.py
@@ -1,8 +1,8 @@
 import coverage
 
-from utils import write_dedup
+from .utils import write_dedup
 
-class CoverageMiddleware:
+class DjangoCoverageMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
@@ -17,3 +17,4 @@ class CoverageMiddleware:
         result = cov.get_data()
         write_dedup(result, id)
         return response
+    

--- a/src/keploy/fastApiCov.py
+++ b/src/keploy/fastApiCov.py
@@ -2,9 +2,9 @@ import coverage
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from utils import write_dedup
+from .utils import write_dedup
 
-class CoverageMiddleware(BaseHTTPMiddleware):
+class FastApiCoverageMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         id = request.headers.get('KEPLOY-TEST-ID')
         if id is None:

--- a/src/keploy/flaskCov.py
+++ b/src/keploy/flaskCov.py
@@ -1,8 +1,8 @@
 import coverage
 
-from utils import write_dedup
+from .utils import write_dedup
 
-class CoverageMiddleware:
+class FlaskCoverageMiddleware:
     def __init__(self, app):
         self.app = app
 

--- a/src/keploy/utils.py
+++ b/src/keploy/utils.py
@@ -1,7 +1,7 @@
 import yaml
 
 def write_dedup(result, id):
-    filePath = '/Users/pranshu/testing/python-fastapi/dedupData.yaml'
+    filePath = 'dedupData.yaml'
     existingData = []
     try:
         with open(filePath, 'r') as file:
@@ -21,3 +21,4 @@ def write_dedup(result, id):
     existingData.append(yaml_data)
     with open(filePath, 'w') as file:
         yaml.dump(existingData, file, sort_keys=False)
+        


### PR DESCRIPTION
Modularized coverage middlewares to be imported directly from Keploy and updated the incorrect path in utils
## Issue that this pull request solves
Dedup not working correctly, coverage middlewares were not able to be imported directly.

Closes: # (issue number)

## Proposed changes

### Brief description of what is fixed or changed

## Types of changes

_Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [ ] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [ ] I have performed a self-review of my own code
-   [ ] I have created new branch for this pull request
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] My changes does not break the current system and it passes all the current test cases.

## Other information

Any other information that is important to this pull request
